### PR TITLE
With the latest PPC64 NMI IPI changes, crash_ipi_callback is found

### DIFF
--- a/ppc64.c
+++ b/ppc64.c
@@ -2337,6 +2337,14 @@ retry:
                         *nip = *up;
                         *ksp = bt->stackbase + 
 				((char *)(up) - 16 - bt->stackbuf);
+			/*
+			 * Check whether this symbol relates to a
+			 * backtrace or not
+			 */
+			ur_ksp =  *(ulong *)&bt->stackbuf[(*ksp) - bt->stackbase];
+			if (!INSTACK(ur_ksp, bt))
+				continue;
+
                         return TRUE;
                 }
 	}


### PR DESCRIPTION
multiple times on the stack of active non-panic tasks.  Ensure that
the symbol reference relates to an actual backtrace stack frame.
(hbathini@linux.vnet.ibm.com)